### PR TITLE
chore(*): performance test 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ POC to test lib tesseract with portuguese and english language.
 
 edit: now just portuguese for performance:
 [test perf](https://github.com/arthurhenrique/go-ocr/pull/1)
+[test perf 2](https://github.com/arthurhenrique/go-ocr/pull/2)
 
 ## Notes
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	tm := TextMethod{
 		Name:     "tesseract",
-		Language: "por+eng",
+		Language: "por",
 		Variables: map[string]string{
 			"tessedit_pageseg_mode": "3", // auto page segmentation mode
 			"load_system_dawg":      "0", // removing dict to increase recognition

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	tm := TextMethod{
 		Name:     "tesseract",
-		Language: "eng",
+		Language: "por+eng",
 		Variables: map[string]string{
 			"tessedit_pageseg_mode": "3", // auto page segmentation mode
 			"load_system_dawg":      "0", // removing dict to increase recognition

--- a/main.go
+++ b/main.go
@@ -12,31 +12,29 @@ func main() {
 	iterations := 50
 	total := time.Duration(0)
 
+	fileName := "files/bode.jpg"
+	bytesImage := convertToBytes(fileName)
+
+	tm := TextMethod{
+		Name:     "tesseract",
+		Language: "eng",
+		Variables: map[string]string{
+			"tessedit_pageseg_mode": "3", // auto page segmentation mode
+			"load_system_dawg":      "0", // removing dict to increase recognition
+			"load_freq_dawg":        "0",
+		},
+		Client: nil,
+	}
+	instance = gosseract.NewClient()
+	defer instance.Close()
+	tm.Client = instance
+
+	tm.tesseractSettings()
+
 	for i := 0; i < iterations; i++ {
 		start := time.Now()
 
-		fileName := "files/bode.jpg"
-
-		// fast model
-		// https://github.com/tesseract-ocr/tessdata_fast/raw/master/por.tra
-		instance = gosseract.NewClient()
-
-		tm := TextMethod{
-			Name:     "tesseract",
-			Language: "por",
-			Variables: map[string]string{
-				"tessedit_pageseg_mode": "3", // auto page segmentation mode
-				"load_system_dawg":      "0", // removing dict to increase recognition
-				"load_freq_dawg":        "0",
-			},
-			Client: instance,
-		}
-		defer instance.Close()
-
 		// Handler tesseract's settings
-		tm.tesseractSettings()
-
-		bytesImage := convertToBytes(fileName)
 		object, err := tm.extract(bytesImage)
 		if err != nil {
 			return


### PR DESCRIPTION
## what is this
Eeach commit has an average of 50 iterations

obs:
Remove bytes convertion and instances of tesseract every time.

infos:
- dpi: 156

## best results
maintaining only Portuguese lang (fast model) 117.332848ms
b36d9ce

## worst result
maintaining English + Portuguese lang (fast model) 158.231926ms
76f4885

Actually ~25% better